### PR TITLE
Auditing 기능 버그 수정

### DIFF
--- a/spadeworker/src/main/java/site/devtown/spadeworker/global/config/audit/AuditorAwareImpl.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/global/config/audit/AuditorAwareImpl.java
@@ -15,10 +15,9 @@ public class AuditorAwareImpl
     @Override
     public Optional<String> getCurrentAuditor() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String userPersonalId = authentication.getName();
 
         return Optional.of(
-                (userPersonalId != null) ? userPersonalId : ""
+                (authentication != null) ? authentication.getName() : ""
         );
     }
 }


### PR DESCRIPTION
Auditing 기능 중 인증된 사용자가 리소스를 생성할 경우 해당 사용자의 정보를 자동으로 엔티티에 주입해주는 기능에서 버그가 발생하여 원인 파악 후 패치하였다.

- 버그 원인 : 인증 된 사용자가 없을 경우 Authentication 객체가 null일 수 있는 상황을 고려하지 못함.
- 진행한 패치 : Authentication 객체가 null일 경우를 대비해서 방어코드를 작성함

This closes #27 