### PR TITLE
Social Login API 요청 URI수정

### DIFF
--- a/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/SecurityConfig.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
         // front 에서 login 시 요청할 url
         http.oauth2Login()
                 .authorizationEndpoint()
-                .baseUri("/oauth2/authorization")
+                .baseUri("/api/oauth2/authorization")
                 .authorizationRequestRepository(oAuth2AuthorizationRequestBasedOnCookieRepository);
 
         // OAuth Server 리다이렉션 주소


### PR DESCRIPTION
API URI 통일성을 위해 Social Login API의 요청 URI를 아래와 같이 변경함

- /oauth2/authorization -> /api/oauth2/authorization

This closes #30 