### PR TITLE
로그아웃 기능 개발

### DIFF
--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/controller/AuthController.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.devtown.spadeworker.domain.auth.service.JwtService;
 import site.devtown.spadeworker.global.factory.YamlPropertySourceFactory;
+import site.devtown.spadeworker.global.response.CommonResult;
 import site.devtown.spadeworker.global.response.ResponseService;
 import site.devtown.spadeworker.global.response.SingleResult;
 import site.devtown.spadeworker.global.util.CookieUtil;
@@ -42,8 +43,6 @@ public class AuthController {
             HttpServletRequest request,
             HttpServletResponse response
     ) {
-        System.out.println("Auth Controller 도착!!!!!");
-
         // access token 확인
         String accessToken = HeaderUtil.getAccessToken(request);
         // refresh token 확인
@@ -66,6 +65,21 @@ public class AuthController {
                 OK.value(),
                 "재발급되었습니다.",
                 newTokens.get("accessToken")
+        );
+    }
+
+    @GetMapping("/logout")
+    public CommonResult logout(
+            HttpServletRequest request
+    ) {
+        // 쿠키에 Refresh Token 삭제
+        jwtService.deleteRefreshToken(
+                HeaderUtil.getAccessToken(request)
+        );
+
+        return responseService.getSuccessResult(
+                OK.value(),
+                "로그아웃 되었습니다."
         );
     }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/repository/UserRefreshTokenRepository.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/repository/UserRefreshTokenRepository.java
@@ -11,4 +11,6 @@ public interface UserRefreshTokenRepository
     Optional<UserRefreshToken> findByPersonalId(String personalId);
 
     Optional<UserRefreshToken> findByPersonalIdAndTokenValue(String personalId, String token);
+
+    void deleteAllByPersonalId(String personalId);
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/service/JwtService.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/service/JwtService.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 
 import static site.devtown.spadeworker.domain.auth.exception.AuthExceptionCode.INVALID_REFRESH_TOKEN;
-import static site.devtown.spadeworker.domain.auth.exception.AuthExceptionCode.INVALID_TOKEN;
 
 @RequiredArgsConstructor
 @Service
@@ -64,6 +63,18 @@ public class JwtService {
                 "accessToken", newAccessToken.getTokenValue(),
                 "refreshToken", newRefreshToken.getTokenValue()
         );
+    }
+
+    /**
+     * 로그아웃 구현을 위해 리프레쉬 토큰 제거
+     */
+    @Transactional
+    public void deleteRefreshToken(String accessToken) {
+        AuthToken accessAuthToken = tokenProvider.convertAccessToken(accessToken);
+        String userPersonalId = accessAuthToken.getTokenClaims().getSubject();
+
+        // refresh token 삭제
+        userRefreshTokenRepository.deleteAllByPersonalId(userPersonalId);
     }
 
     private Claims getTokenClaims(AuthToken token) {


### PR DESCRIPTION
로그아웃 기능 구현을 위해 사용자의 personalId와 매핑되는 refresh token을 모두 삭제하는 로직을 작성하였다.

This closes #32 