### PR TITLE
사용자 권한 인가 로직 refactoring

### DIFF
--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/exception/AuthExceptionHandler.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/exception/AuthExceptionHandler.java
@@ -143,18 +143,4 @@ public class AuthExceptionHandler {
                 HttpStatus.valueOf(EXPIRED_TOKEN.getHttpStatus().value())
         );
     }
-
-    /**
-     * IllegalArgumentException 예외 핸들링
-     */
-    @ExceptionHandler(IllegalArgumentException.class)
-    protected ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(
-            IllegalArgumentException e
-    ) {
-        log.error("handle IllegalArgumentException");
-        return new ResponseEntity<>(
-                ExceptionResponse.of(INVALID_TOKEN_COMPACT, INVALID_TOKEN_COMPACT.getMessage()),
-                HttpStatus.valueOf(INVALID_TOKEN_COMPACT.getHttpStatus().value())
-        );
-    }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -12,8 +12,8 @@ import site.devtown.spadeworker.domain.auth.model.info.OAuth2UserInfo;
 import site.devtown.spadeworker.domain.auth.model.info.OAuth2UserInfoFactory;
 import site.devtown.spadeworker.domain.auth.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
 import site.devtown.spadeworker.domain.auth.repository.UserRefreshTokenRepository;
+import site.devtown.spadeworker.domain.auth.service.JwtService;
 import site.devtown.spadeworker.domain.auth.token.AuthToken;
-import site.devtown.spadeworker.domain.auth.token.AuthTokenProvider;
 import site.devtown.spadeworker.domain.auth.token.UserRefreshToken;
 import site.devtown.spadeworker.domain.user.model.constant.AuthProviderType;
 import site.devtown.spadeworker.domain.user.model.constant.UserRoleType;
@@ -39,8 +39,7 @@ import static site.devtown.spadeworker.domain.auth.repository.OAuth2Authorizatio
 @RequiredArgsConstructor
 public class OAuth2AuthenticationSuccessHandler
         extends SimpleUrlAuthenticationSuccessHandler {
-
-    private final AuthTokenProvider jwtProvider;
+    private final JwtService jwtService;
     private final UserRefreshTokenRepository userRefreshTokenRepository;
     private final OAuth2AuthorizationRequestBasedOnCookieRepository authorizationRequestRepository;
     private final RoleRepository roleRepository;
@@ -97,7 +96,7 @@ public class OAuth2AuthenticationSuccessHandler
         ).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 권한입니다."));
 
         // access token 생성
-        AuthToken accessToken = jwtProvider.createAccessToken(
+        AuthToken accessToken = jwtService.createAccessToken(
                 userInfo.getId(),
                 List.of(role.getRoleType())
         );
@@ -105,7 +104,7 @@ public class OAuth2AuthenticationSuccessHandler
         log.info("[Access-Token] = {}", accessToken.getTokenValue());
 
         // refresh 토큰 생성
-        AuthToken refreshToken = jwtProvider.createRefreshToken(
+        AuthToken refreshToken = jwtService.createRefreshToken(
                 userInfo.getId(),
                 List.of(role.getRoleType())
         );

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/model/UserPrincipal.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/model/UserPrincipal.java
@@ -1,38 +1,43 @@
 package site.devtown.spadeworker.domain.auth.model;
 
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import site.devtown.spadeworker.domain.user.model.constant.AuthProviderType;
-import site.devtown.spadeworker.domain.user.model.constant.UserRoleType;
 import site.devtown.spadeworker.domain.user.model.constant.UserStatus;
 import site.devtown.spadeworker.domain.user.model.entity.User;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 public record UserPrincipal(
         String personalId,
         AuthProviderType providerType,
-        UserStatus status,
-        List<UserRoleType> roles,
+        UserStatus userStatus,
+        Collection<GrantedAuthority> authorities,
         Map<String, Object> oAuth2UserInfoAttributes
 ) implements UserDetails, OAuth2User, OidcUser {
+
     public static UserPrincipal from(
             User user,
-            List<UserRoleType> roles,
+            Collection<GrantedAuthority> authorities
+    ) {
+        return from(user, authorities, null);
+    }
+
+    public static UserPrincipal from(
+            User user,
+            Collection<GrantedAuthority> authorities,
             Map<String, Object> oAuth2UserInfo
     ) {
         return new UserPrincipal(
                 user.getPersonalId(),
                 user.getProviderType(),
                 user.getStatus(),
-                roles,
+                authorities,
                 oAuth2UserInfo
         );
     }
@@ -44,9 +49,7 @@ public record UserPrincipal(
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return roles.stream()
-                .map(r -> new SimpleGrantedAuthority(r.toString()))
-                .toList();
+        return this.authorities;
     }
 
     @Override
@@ -66,22 +69,22 @@ public record UserPrincipal(
 
     @Override
     public boolean isAccountNonExpired() {
-        return this.status == UserStatus.ACTIVE;
+        return this.userStatus == UserStatus.ACTIVE;
     }
 
     @Override
     public boolean isAccountNonLocked() {
-        return this.status == UserStatus.ACTIVE;
+        return this.userStatus == UserStatus.ACTIVE;
     }
 
     @Override
     public boolean isCredentialsNonExpired() {
-        return this.status == UserStatus.ACTIVE;
+        return this.userStatus == UserStatus.ACTIVE;
     }
 
     @Override
     public boolean isEnabled() {
-        return this.status == UserStatus.ACTIVE;
+        return this.userStatus == UserStatus.ACTIVE;
     }
 
     @Override
@@ -97,5 +100,17 @@ public record UserPrincipal(
     @Override
     public OidcIdToken getIdToken() {
         return null;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getClass().getName()).append(" [");
+        sb.append("personalId=").append(this.personalId).append(", ");
+        sb.append("providerType=").append(this.providerType).append(", ");
+        sb.append("userStatus=").append(this.userStatus).append(", ");
+        sb.append("Granted Authorities=").append(this.authorities).append("], ");
+        sb.append("oAuth2UserInfoAttributes=[PROTECTED]");
+        return sb.toString();
     }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/service/JwtService.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/service/JwtService.java
@@ -3,19 +3,30 @@ package site.devtown.spadeworker.domain.auth.service;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.devtown.spadeworker.domain.auth.exception.ExpiredTokenException;
 import site.devtown.spadeworker.domain.auth.exception.NotExpiredTokenException;
 import site.devtown.spadeworker.domain.auth.exception.TokenValidFailedException;
+import site.devtown.spadeworker.domain.auth.model.UserPrincipal;
 import site.devtown.spadeworker.domain.auth.repository.UserRefreshTokenRepository;
 import site.devtown.spadeworker.domain.auth.token.AuthToken;
 import site.devtown.spadeworker.domain.auth.token.AuthTokenProvider;
 import site.devtown.spadeworker.domain.auth.token.UserRefreshToken;
 import site.devtown.spadeworker.domain.user.model.constant.UserRoleType;
+import site.devtown.spadeworker.domain.user.model.entity.User;
+import site.devtown.spadeworker.domain.user.repository.UserRepository;
 
+import javax.persistence.EntityNotFoundException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static site.devtown.spadeworker.domain.auth.exception.AuthExceptionCode.INVALID_REFRESH_TOKEN;
 
@@ -23,8 +34,29 @@ import static site.devtown.spadeworker.domain.auth.exception.AuthExceptionCode.I
 @Service
 public class JwtService {
 
+    private final UserRepository userRepository;
     private final UserRefreshTokenRepository userRefreshTokenRepository;
     private final AuthTokenProvider tokenProvider;
+
+    /**
+     * Access Token 생성
+     */
+    public AuthToken createAccessToken(
+            String personalId,
+            List<UserRoleType> roles
+    ) {
+        return tokenProvider.generateAccessToken(personalId, roles);
+    }
+
+    /**
+     * Refresh Token 생성
+     */
+    public AuthToken createRefreshToken(
+            String personalId,
+            List<UserRoleType> roles
+    ) {
+        return tokenProvider.generateRefreshToken(personalId, roles);
+    }
 
     /**
      * refresh token 확인 후 토큰 전체 재발급
@@ -34,13 +66,13 @@ public class JwtService {
             String accessToken,
             String refreshToken
     ) {
-        AuthToken authToken = tokenProvider.convertAccessToken(accessToken);
+        AuthToken authToken = createAuthTokenFromAccessTokenValue(accessToken);
         Claims claims = getTokenClaims(authToken);
 
         String userId = claims.getSubject();
         UserRoleType roleType = UserRoleType.of(claims.get("roles", String.class));
 
-        AuthToken authRefreshToken = tokenProvider.convertRefreshToken(refreshToken);
+        AuthToken authRefreshToken = createAuthTokenFromRefreshTokenValue(refreshToken);
 
         // refreshToken 검증
         validateRefreshToken(authRefreshToken);
@@ -51,11 +83,11 @@ public class JwtService {
                 refreshToken
         ).orElseThrow(() -> new TokenValidFailedException(INVALID_REFRESH_TOKEN.getMessage()));
 
-        AuthToken newAccessToken = tokenProvider.createAccessToken(userId, List.of(roleType));
+        AuthToken newAccessToken = createAccessToken(userId, List.of(roleType));
 
         // Refresh Token Rotation
         // refresh 토큰 설정
-        AuthToken newRefreshToken = tokenProvider.createRefreshToken(userId, List.of(roleType));
+        AuthToken newRefreshToken = createRefreshToken(userId, List.of(roleType));
         // DB에 refresh 토큰 업데이트
         userRefreshToken.changeTokenValue(newRefreshToken.getTokenValue());
 
@@ -70,13 +102,53 @@ public class JwtService {
      */
     @Transactional
     public void deleteRefreshToken(String accessToken) {
-        AuthToken accessAuthToken = tokenProvider.convertAccessToken(accessToken);
+        AuthToken accessAuthToken = createAuthTokenFromAccessTokenValue(accessToken);
         String userPersonalId = accessAuthToken.getTokenClaims().getSubject();
 
         // refresh token 삭제
         userRefreshTokenRepository.deleteAllByPersonalId(userPersonalId);
     }
 
+    /**
+     * JWT 값을 기반으로 사용자 인가 조회
+     */
+    public Authentication getAuthentication(AuthToken token) {
+        if (!token.validate()) {
+            throw new TokenValidFailedException();
+        }
+
+        Claims claims = token.getTokenClaims();
+        // claims 값을 기반으로 사용자 Entity 조회
+        User user = userRepository.findByPersonalId(claims.getSubject())
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사용자입니다."));
+        // claims 값을 기반으로 사용자의 권한 조회
+        Collection<GrantedAuthority> authorities = Arrays.stream(new String[]{claims.get("roles").toString()})
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+        UserPrincipal userPrincipal = UserPrincipal.from(user, authorities);
+
+        return new UsernamePasswordAuthenticationToken(
+                userPrincipal,
+                token,
+                userPrincipal.getAuthorities()
+        );
+    }
+
+    /**
+     * access-token 문자열 값을 기반으로 AuthToken 객체 생성
+     */
+    public AuthToken createAuthTokenFromAccessTokenValue(String accessToken) {
+        return tokenProvider.convertAccessTokenToAuthToken(accessToken);
+    }
+
+    /**
+     * refresh-token 문자열 값을 기반으로 AuthToken 객체 생성
+     */
+    public AuthToken createAuthTokenFromRefreshTokenValue(String refreshToken) {
+        return tokenProvider.convertRefreshTokenToAuthToken(refreshToken);
+    }
+
+    // 토큰 Claim 정보 조회
     private Claims getTokenClaims(AuthToken token) {
         Claims claims = null;
         try {
@@ -92,6 +164,7 @@ public class JwtService {
         return claims;
     }
 
+    // 리프레쉬 토큰 검증
     private void validateRefreshToken(AuthToken token) {
         try {
             token.validate();

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/token/AuthToken.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/token/AuthToken.java
@@ -14,7 +14,6 @@ import static site.devtown.spadeworker.domain.auth.exception.AuthExceptionCode.*
 
 @Slf4j
 public class AuthToken {
-
     @Getter
     private final String tokenValue;
     private final Key key;

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/token/AuthTokenProvider.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/token/AuthTokenProvider.java
@@ -1,23 +1,13 @@
 package site.devtown.spadeworker.domain.auth.token;
 
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import site.devtown.spadeworker.domain.auth.exception.TokenValidFailedException;
 import site.devtown.spadeworker.domain.user.model.constant.UserRoleType;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 public class AuthTokenProvider {
@@ -43,7 +33,7 @@ public class AuthTokenProvider {
     /**
      * Access Token 생성
      */
-    public AuthToken createAccessToken(
+    public AuthToken generateAccessToken(
             String personalId,
             List<UserRoleType> roles
     ) {
@@ -58,7 +48,7 @@ public class AuthTokenProvider {
     /**
      * Refresh Token 생성
      */
-    public AuthToken createRefreshToken(
+    public AuthToken generateRefreshToken(
             String personalId,
             List<UserRoleType> roles
     ) {
@@ -73,36 +63,14 @@ public class AuthTokenProvider {
     /**
      * Access Token 값을 기반으로 AuthToken 객체 생성
      */
-    public AuthToken convertAccessToken(String accessToken) {
+    public AuthToken convertAccessTokenToAuthToken(String accessToken) {
         return AuthToken.of(accessToken, accessTokenSecretKey);
     }
 
     /**
      * Refresh Token 값을 기반으로 AuthToken 객체 생성
      */
-    public AuthToken convertRefreshToken(String refreshToken) {
+    public AuthToken convertRefreshTokenToAuthToken(String refreshToken) {
         return AuthToken.of(refreshToken, refreshTokenSecretKey);
-    }
-
-    /**
-     * 토큰으로 사용자 인가 조회
-     */
-    public Authentication getAuthentication(AuthToken token) {
-        if (!token.validate()) {
-            throw new TokenValidFailedException();
-        }
-
-        Claims claims = token.getTokenClaims();
-        Collection<? extends GrantedAuthority> authorities = Arrays.stream(new String[]{claims.get("roles").toString()})
-                .map(SimpleGrantedAuthority::new)
-                .collect(Collectors.toList());
-
-        User userPrincipal = new User(claims.getSubject(), "", authorities);
-
-        return new UsernamePasswordAuthenticationToken(
-                userPrincipal,
-                token,
-                userPrincipal.getAuthorities()
-        );
     }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/JwtConfig.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/JwtConfig.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-import site.devtown.spadeworker.domain.auth.filter.TokenAuthenticationFilter;
 import site.devtown.spadeworker.domain.auth.token.AuthTokenProvider;
 import site.devtown.spadeworker.global.factory.YamlPropertySourceFactory;
 
@@ -35,13 +34,5 @@ public class JwtConfig {
                 refreshTokenSecretKey,
                 refreshTokenExpiry
         );
-    }
-
-    /*
-     * 토큰 검증 필터 설정
-     * */
-    @Bean
-    public TokenAuthenticationFilter tokenAuthenticationFilter() {
-        return new TokenAuthenticationFilter(jwtProvider());
     }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/OAuth2Config.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/OAuth2Config.java
@@ -11,7 +11,7 @@ import site.devtown.spadeworker.domain.auth.handler.OAuth2AuthenticationSuccessH
 import site.devtown.spadeworker.domain.auth.handler.TokenAccessDeniedHandler;
 import site.devtown.spadeworker.domain.auth.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
 import site.devtown.spadeworker.domain.auth.repository.UserRefreshTokenRepository;
-import site.devtown.spadeworker.domain.auth.token.AuthTokenProvider;
+import site.devtown.spadeworker.domain.auth.service.JwtService;
 import site.devtown.spadeworker.domain.user.repository.RoleRepository;
 
 import java.util.List;
@@ -23,7 +23,7 @@ import java.util.List;
 @Configuration
 public class OAuth2Config {
 
-    private final AuthTokenProvider tokenProvider;
+    private final JwtService jwtService;
     private final UserRefreshTokenRepository userRefreshTokenRepository;
     private final RoleRepository roleRepository;
     private final HandlerExceptionResolver handlerExceptionResolver;
@@ -48,7 +48,7 @@ public class OAuth2Config {
     @Bean
     public OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler() {
         return new OAuth2AuthenticationSuccessHandler(
-                tokenProvider,
+                jwtService,
                 userRefreshTokenRepository,
                 oAuth2AuthorizationRequestBasedOnCookieRepository(),
                 roleRepository,


### PR DESCRIPTION
사용자 인증 후 권한을 인가하는 로직 중 맘에들지 않았던 부분을 분석한 후 리펙토링 하였다.

- 기존 시큐리티에서 지원하는 User클래스 대신 직접 정의한 UserPrincipal 클래스가 사용자 권한 인가시 생성되도록 리펙토링
- AuthTokenProvider의 역할은 모두 JwtService를 통해서 진행되도록 리펙토링
- AuthTokenProvider의 토큰을 기반으로 사용자의 권한을 조회하는 메서드를 JwtService로 이동

This closes #37 