### PR TITLE
인증 성공시 사용자의 인가 권한 리스트를 부여하는 로직 개선

### DIFF
--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/exception/AuthExceptionCode.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/exception/AuthExceptionCode.java
@@ -29,6 +29,7 @@ public enum AuthExceptionCode
      * 100 ~ 199
      */
     OAUTH_PROVIDER_MISMATCH(BAD_REQUEST, "AT-C-100", "일치하지 않는 인증 제공자 입니다."),
+    INVALID_USER_ROLE(FORBIDDEN, "AT-C-101", "유효하지 않은 사용자 권한입니다."),
 
     /**
      * Common Exception

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/handler/TokenAccessDeniedHandler.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/handler/TokenAccessDeniedHandler.java
@@ -3,16 +3,17 @@ package site.devtown.spadeworker.domain.auth.handler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
-import org.springframework.web.servlet.HandlerExceptionResolver;
+import site.devtown.spadeworker.global.exception.ExceptionResponse;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static site.devtown.spadeworker.domain.auth.exception.AuthExceptionCode.INVALID_USER_ROLE;
+
 @RequiredArgsConstructor
 public class TokenAccessDeniedHandler
         implements AccessDeniedHandler {
-    private final HandlerExceptionResolver handlerExceptionResolver;
 
     @Override
     public void handle(
@@ -20,7 +21,15 @@ public class TokenAccessDeniedHandler
             HttpServletResponse response,
             AccessDeniedException accessDeniedException
     ) throws IOException {
-        // TODO : 아래 주석 처리 된 로직 분석하기
-        handlerExceptionResolver.resolveException(request, response, null, accessDeniedException);
+        setResponse(response);
+    }
+
+    // 한글 출력을 위해 getWriter() 사용
+    private void setResponse(
+            HttpServletResponse response
+    ) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter().print(ExceptionResponse.of(INVALID_USER_ROLE).convertJson());
     }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/model/UserPrincipal.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/model/UserPrincipal.java
@@ -18,20 +18,20 @@ public record UserPrincipal(
         String personalId,
         AuthProviderType providerType,
         UserStatus userStatus,
-        Collection<GrantedAuthority> authorities,
+        Collection<? extends GrantedAuthority> authorities,
         Map<String, Object> oAuth2UserInfoAttributes
 ) implements UserDetails, OAuth2User, OidcUser {
 
     public static UserPrincipal from(
             User user,
-            Collection<GrantedAuthority> authorities
+            Collection<? extends GrantedAuthority> authorities
     ) {
         return from(user, authorities, null);
     }
 
     public static UserPrincipal from(
             User user,
-            Collection<GrantedAuthority> authorities,
+            Collection<? extends GrantedAuthority> authorities,
             Map<String, Object> oAuth2UserInfo
     ) {
         return new UserPrincipal(

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/service/CustomOAuth2UserService.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/service/CustomOAuth2UserService.java
@@ -78,14 +78,10 @@ public class CustomOAuth2UserService
         // 계정이 존재하지 않을 경우 회원 가입을 진행
         User user = userRepository.findByPersonalId(userInfo.getId())
                 .orElseGet(() -> createUser(userInfo, providerType));
-        // TODO : 아래 로직을 더 줄일 수 있는지 고민하고 리펙토링
         Collection<GrantedAuthority> authorities = userRoleRepository.findAllByUser(user)
                 .orElseThrow(() -> new EntityNotFoundException("사용자 권한이 존재하지 않습니다."))
                 .stream()
-                .map(r -> r.getRole().getRoleType())
-                .toList()
-                .stream()
-                .map(r -> new SimpleGrantedAuthority(r.toString()))
+                .map(r -> new SimpleGrantedAuthority(r.getRole().getRoleType().getCode()))
                 .collect(Collectors.toList());
 
         // 회원 가입 된 계정의 로그인 유형과 현재 로그인 한 유형이 일치한지 검증

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/token/AuthToken.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/token/AuthToken.java
@@ -3,13 +3,13 @@ package site.devtown.spadeworker.domain.auth.token;
 import io.jsonwebtoken.*;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.GrantedAuthority;
 import site.devtown.spadeworker.domain.auth.exception.InvalidTokenException;
 import site.devtown.spadeworker.domain.auth.exception.NotExpiredTokenException;
-import site.devtown.spadeworker.domain.user.model.constant.UserRoleType;
 
 import java.security.Key;
+import java.util.Collection;
 import java.util.Date;
-import java.util.List;
 import java.util.stream.Collectors;
 
 import static site.devtown.spadeworker.domain.auth.exception.AuthExceptionCode.*;
@@ -22,7 +22,7 @@ public class AuthToken {
 
     private AuthToken(
             String personalId,
-            List<UserRoleType> roles,
+            Collection<? extends GrantedAuthority> roles,
             Date expiry,
             Key key
     ) {
@@ -32,7 +32,7 @@ public class AuthToken {
 
     public static AuthToken of(
             String personalId,
-            List<UserRoleType> roles,
+            Collection<? extends GrantedAuthority> roles,
             Date expiry,
             Key key
     ) {
@@ -59,11 +59,11 @@ public class AuthToken {
      */
     private String generateAccessTokenValue(
             String personalId,
-            List<UserRoleType> userRoles,
+            Collection<? extends GrantedAuthority> userRoles,
             Date expiry
     ) {
         String roles = userRoles.stream()
-                .map(UserRoleType::toString)
+                .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
         Claims claims = Jwts.claims()

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/token/AuthTokenProvider.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/token/AuthTokenProvider.java
@@ -2,12 +2,12 @@ package site.devtown.spadeworker.domain.auth.token;
 
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
-import site.devtown.spadeworker.domain.user.model.constant.UserRoleType;
+import org.springframework.security.core.GrantedAuthority;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.util.Collection;
 import java.util.Date;
-import java.util.List;
 
 @Slf4j
 public class AuthTokenProvider {
@@ -35,7 +35,7 @@ public class AuthTokenProvider {
      */
     public AuthToken generateAccessToken(
             String personalId,
-            List<UserRoleType> roles
+            Collection<? extends GrantedAuthority> roles
     ) {
         return AuthToken.of(
                 personalId,
@@ -50,7 +50,7 @@ public class AuthTokenProvider {
      */
     public AuthToken generateRefreshToken(
             String personalId,
-            List<UserRoleType> roles
+            Collection<? extends GrantedAuthority> roles
     ) {
         return AuthToken.of(
                 personalId,

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/user/model/constant/UserRoleType.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/user/model/constant/UserRoleType.java
@@ -3,8 +3,6 @@ package site.devtown.spadeworker.domain.user.model.constant;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import java.util.Arrays;
-
 @Getter
 @RequiredArgsConstructor
 public enum UserRoleType {
@@ -15,11 +13,4 @@ public enum UserRoleType {
 
     private final String code;
     private final String title;
-
-    public static UserRoleType of(String code) {
-        return Arrays.stream(UserRoleType.values())
-                .filter(r -> r.getCode().equals(code))
-                .findAny()
-                .orElse(GUEST);
-    }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/OAuth2Config.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/OAuth2Config.java
@@ -5,14 +5,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.web.servlet.HandlerExceptionResolver;
 import site.devtown.spadeworker.domain.auth.handler.OAuth2AuthenticationFailureHandler;
 import site.devtown.spadeworker.domain.auth.handler.OAuth2AuthenticationSuccessHandler;
 import site.devtown.spadeworker.domain.auth.handler.TokenAccessDeniedHandler;
 import site.devtown.spadeworker.domain.auth.repository.OAuth2AuthorizationRequestBasedOnCookieRepository;
 import site.devtown.spadeworker.domain.auth.repository.UserRefreshTokenRepository;
 import site.devtown.spadeworker.domain.auth.service.JwtService;
-import site.devtown.spadeworker.domain.user.repository.RoleRepository;
 
 import java.util.List;
 
@@ -25,8 +23,6 @@ public class OAuth2Config {
 
     private final JwtService jwtService;
     private final UserRefreshTokenRepository userRefreshTokenRepository;
-    private final RoleRepository roleRepository;
-    private final HandlerExceptionResolver handlerExceptionResolver;
 
     @Value("${oauth2.authorized-redirect-uris}")
     private List<String> authorizedRedirectUris;
@@ -67,12 +63,10 @@ public class OAuth2Config {
     }
 
     /**
-     * 토큰 접근 거부 핸들러
+     * 사용자 인가 오류 처리 핸들러
      */
     @Bean
     public TokenAccessDeniedHandler tokenAccessDeniedHandler() {
-        return new TokenAccessDeniedHandler(
-                handlerExceptionResolver
-        );
+        return new TokenAccessDeniedHandler();
     }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/OAuth2Config.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/OAuth2Config.java
@@ -51,7 +51,6 @@ public class OAuth2Config {
                 jwtService,
                 userRefreshTokenRepository,
                 oAuth2AuthorizationRequestBasedOnCookieRepository(),
-                roleRepository,
                 authorizedRedirectUris,
                 cookieMaxAge
         );


### PR DESCRIPTION
인증에 성공한 사용자의 권한을 부여하는 로직을 다음과 같이 개선하였다.

- 기존 AuthToken Class에 작성된 사용자 권한 설정 로직의 데이터 타입을 SimpleGrantAuthority로 변경하고 관련 Class에 수정 사항을 반영
- CustomOAuth2UserService에 사용된 비효율적인 stream 코드를 개선
- TokenAccessDeniedHandler Class의 로직 개선

This Closes #41 