### PR TITLE
[Fix] Token을 재발급시 토큰의 만료기간이 잘못 설정되는 버그 조치

### DIFF
--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/token/AuthTokenProvider.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/token/AuthTokenProvider.java
@@ -14,8 +14,8 @@ public class AuthTokenProvider {
 
     private final Key accessTokenSecretKey;
     private final Key refreshTokenSecretKey;
-    private final Date accessTokenExpiry;
-    private final Date refreshTokenExpiry;
+    private final long accessTokenExpiry;
+    private final long refreshTokenExpiry;
 
     public AuthTokenProvider(
             String accessTokenSecretKey,
@@ -26,8 +26,8 @@ public class AuthTokenProvider {
     ) {
         this.accessTokenSecretKey = Keys.hmacShaKeyFor(accessTokenSecretKey.getBytes(StandardCharsets.UTF_8));
         this.refreshTokenSecretKey = Keys.hmacShaKeyFor(refreshTokenSecretKey.getBytes(StandardCharsets.UTF_8));
-        this.accessTokenExpiry = new Date(new Date().getTime() + accessTokenExpiry);
-        this.refreshTokenExpiry = new Date(new Date().getTime() + refreshTokenExpiry);
+        this.accessTokenExpiry = accessTokenExpiry;
+        this.refreshTokenExpiry = refreshTokenExpiry;
     }
 
     /**
@@ -40,7 +40,7 @@ public class AuthTokenProvider {
         return AuthToken.of(
                 personalId,
                 roles,
-                accessTokenExpiry,
+                new Date(new Date().getTime() + accessTokenExpiry),
                 accessTokenSecretKey
         );
     }
@@ -55,7 +55,7 @@ public class AuthTokenProvider {
         return AuthToken.of(
                 personalId,
                 roles,
-                refreshTokenExpiry,
+                new Date(new Date().getTime() + refreshTokenExpiry),
                 refreshTokenSecretKey
         );
     }


### PR DESCRIPTION
Token 생성 시 때때로 만료기간이 생성기간보다 빠른 시간대로 잡혀 토큰이 만료된 채로 발급되는 버그가 발생하여 문제를 분석 후 해결하였다.

- 원인 : TokenProvider를 JwtConfig에서 생성자 주입 후 빈을 생성할때 TokenProvider 내부에 토큰의 우효 시간이 아닌 Date를 통한 구체적인 날짜로 필드가 잘못 설계되어 있어서 발생하는 문제였다.
- 진행한 조치 : 따라서 올바른 필드로 수정하여 문제를 해결해주었다.

This closes #43 