### PR TITLE
#45 - Project 응답 항목에 프로젝트 좋아요 수 & 구독자 수 추가

### DIFF
--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/dto/ProjectDto.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/dto/ProjectDto.java
@@ -10,15 +10,23 @@ public record ProjectDto(
         String title,
         String description,
         String thumbnailImageUri,
+        int likeCount,
+        int subscriberCount,
         UserInfo user,
         LocalDateTime createdAt
 ) {
-    public static ProjectDto from(Project project) {
+    public static ProjectDto from(
+            Project project,
+            int likeCount,
+            int subscriberCount
+    ) {
         return new ProjectDto(
                 project.getId(),
                 project.getTitle(),
                 project.getDescription(),
                 project.getThumbnailImageUri(),
+                likeCount,
+                subscriberCount,
                 UserInfo.from(project.getUser()),
                 project.getCreatedAt()
         );

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/repository/ProjectLikeRepository.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/repository/ProjectLikeRepository.java
@@ -13,4 +13,6 @@ public interface ProjectLikeRepository
     Boolean existsByProjectAndUser(Project project, User user);
 
     Optional<ProjectLike> findByProjectAndUser(Project project, User user);
+
+    int countAllByProject(Project project);
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/repository/ProjectSubscribeRepository.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/repository/ProjectSubscribeRepository.java
@@ -13,4 +13,6 @@ public interface ProjectSubscribeRepository
     Boolean existsByProjectAndSubscriber(Project project, User subscriber);
 
     Optional<ProjectSubscribe> findByProjectAndSubscriber(Project project, User subscriber);
+
+    int countAllByProject(Project project);
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/service/ProjectService.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/service/ProjectService.java
@@ -60,7 +60,11 @@ public class ProjectService {
     public List<ProjectDto> getAllProjects() {
         return projectRepository.findAll()
                 .stream()
-                .map(ProjectDto::from)
+                .map(p -> ProjectDto.from(
+                        p,
+                        projectLikeRepository.countAllByProject(p),
+                        projectSubscribeRepository.countAllByProject(p))
+                )
                 .toList();
     }
 
@@ -72,7 +76,11 @@ public class ProjectService {
             Long projectId
     ) {
         return projectRepository.findById(projectId)
-                .map(ProjectDto::from)
+                .map(p -> ProjectDto.from(
+                        p,
+                        projectLikeRepository.countAllByProject(p),
+                        projectSubscribeRepository.countAllByProject(p))
+                )
                 .orElseThrow(
                         () -> new ResourceNotFoundException(PROJECT_NOT_FOUND)
                 );


### PR DESCRIPTION
project를 단건 & 전체 조회 시 해당 프로젝트의 좋아요 수와 구독자 수가 함께 응답에 포함될 수 있도록 리펙토링 해주었다.

This closes #48 