### PR TITLE
프로젝트 도메인 좋아요 및 구독 시스템 개발

### DIFF
--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/controller/ProjectController.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/controller/ProjectController.java
@@ -112,4 +112,36 @@ public class ProjectController {
                 "성공적으로 프로젝트의 좋아요가 취소되었습니다."
         );
     }
+
+    /**
+     * 프로젝트 구독 API
+     */
+    @PostMapping("/{projectId}/subscribe")
+    public CommonResult registerProjectSubscribe(
+            @PathVariable Long projectId
+    ) {
+        // 프로젝트 구독
+        projectService.registerProjectSubscribe(projectId);
+
+        return responseService.getSuccessResult(
+                OK.value(),
+                "성공적으로 프로젝트에 구독되었습니다."
+        );
+    }
+
+    /**
+     * 프로젝트 구독 취소 API
+     */
+    @DeleteMapping("/{projectId}/subscribe")
+    public CommonResult cancelProjectSubscribe(
+            @PathVariable Long projectId
+    ) {
+        // 프로젝트 구독 취소
+        projectService.cancelProjectSubscribe(projectId);
+
+        return responseService.getSuccessResult(
+                OK.value(),
+                "성공적으로 프로젝트의 구독이 취소되었습니다."
+        );
+    }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/controller/ProjectController.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/controller/ProjectController.java
@@ -6,6 +6,7 @@ import site.devtown.spadeworker.domain.project.dto.CreateProjectRequest;
 import site.devtown.spadeworker.domain.project.dto.ProjectDto;
 import site.devtown.spadeworker.domain.project.dto.UpdateProjectRequest;
 import site.devtown.spadeworker.domain.project.service.ProjectService;
+import site.devtown.spadeworker.global.response.CommonResult;
 import site.devtown.spadeworker.global.response.ListResult;
 import site.devtown.spadeworker.global.response.ResponseService;
 import site.devtown.spadeworker.global.response.SingleResult;
@@ -77,6 +78,38 @@ public class ProjectController {
                         projectId,
                         request
                 )
+        );
+    }
+
+    /**
+     * 프로젝트 좋아요 등록 API
+     */
+    @PostMapping("/{projectId}/like")
+    public CommonResult registerProjectLike(
+            @PathVariable Long projectId
+    ) {
+        // 프로젝트에 좋아요 등록
+        projectService.registerProjectLike(projectId);
+
+        return responseService.getSuccessResult(
+                OK.value(),
+                "성공적으로 프로젝트에 좋아요가 등록되었습니다."
+        );
+    }
+
+    /**
+     * 프로젝트 좋아요 취소 API
+     */
+    @DeleteMapping("/{projectId}/like")
+    public CommonResult cancelProjectLike(
+            @PathVariable Long projectId
+    ) {
+        // 프로젝트의 좋아요 취소
+        projectService.cancelProjectLike(projectId);
+
+        return responseService.getSuccessResult(
+                OK.value(),
+                "성공적으로 프로젝트의 좋아요가 취소되었습니다."
         );
     }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/dto/ProjectDto.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/dto/ProjectDto.java
@@ -10,15 +10,23 @@ public record ProjectDto(
         String title,
         String description,
         String thumbnailImageUri,
+        int likeCount,
+        int subscriberCount,
         UserInfo user,
         LocalDateTime createdAt
 ) {
-    public static ProjectDto from(Project project) {
+    public static ProjectDto from(
+            Project project,
+            int likeCount,
+            int subscriberCount
+    ) {
         return new ProjectDto(
                 project.getId(),
                 project.getTitle(),
                 project.getDescription(),
                 project.getThumbnailImageUri(),
+                likeCount,
+                subscriberCount,
                 UserInfo.from(project.getUser()),
                 project.getCreatedAt()
         );

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectDuplicateLikeException.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectDuplicateLikeException.java
@@ -1,7 +1,9 @@
 package site.devtown.spadeworker.domain.project.exception;
 
+import static site.devtown.spadeworker.domain.project.exception.ProjectExceptionCode.*;
+
 public class ProjectDuplicateLikeException extends RuntimeException {
     public ProjectDuplicateLikeException() {
-        super("프로젝트에 이미 해당 사용자의 좋아요가 존재합니다.");
+        super(PROJECT_DUPLICATE_LIKE.getMessage());
     }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectDuplicateLikeException.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectDuplicateLikeException.java
@@ -1,0 +1,7 @@
+package site.devtown.spadeworker.domain.project.exception;
+
+public class ProjectDuplicateLikeException extends RuntimeException {
+    public ProjectDuplicateLikeException() {
+        super("프로젝트에 이미 해당 사용자의 좋아요가 존재합니다.");
+    }
+}

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectDuplicateSubscribeException.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectDuplicateSubscribeException.java
@@ -1,0 +1,9 @@
+package site.devtown.spadeworker.domain.project.exception;
+
+import static site.devtown.spadeworker.domain.project.exception.ProjectExceptionCode.*;
+
+public class ProjectDuplicateSubscribeException extends RuntimeException {
+    public ProjectDuplicateSubscribeException() {
+        super(PROJECT_DUPLICATE_SUBSCRIBE.getMessage());
+    }
+}

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectExceptionCode.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectExceptionCode.java
@@ -13,7 +13,9 @@ public enum ProjectExceptionCode
         implements ExceptionCode {
 
     PROJECT_NOT_FOUND(NOT_FOUND, "PJ-C-001", "존재하지 않는 프로젝트입니다."),
-    INVALID_PROJECT_OWNER(FORBIDDEN, "PJ-C-002", "프로젝트를 처리할 권한이 없습니다.");
+    INVALID_PROJECT_OWNER(FORBIDDEN, "PJ-C-002", "프로젝트를 처리할 권한이 없습니다."),
+    PROJECT_DUPLICATE_LIKE(BAD_REQUEST, "PJ-C-003", "프로젝트에 이미 해당 사용자의 좋아요가 존재합니다."),
+    PROJECT_LIKE_NOT_FOUND(NOT_FOUND, "PJ-C-004", "프로젝트에 해당 사용자의 좋아요가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectExceptionCode.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectExceptionCode.java
@@ -15,7 +15,9 @@ public enum ProjectExceptionCode
     PROJECT_NOT_FOUND(NOT_FOUND, "PJ-C-001", "존재하지 않는 프로젝트입니다."),
     INVALID_PROJECT_OWNER(FORBIDDEN, "PJ-C-002", "프로젝트를 처리할 권한이 없습니다."),
     PROJECT_DUPLICATE_LIKE(BAD_REQUEST, "PJ-C-003", "프로젝트에 이미 해당 사용자의 좋아요가 존재합니다."),
-    PROJECT_LIKE_NOT_FOUND(NOT_FOUND, "PJ-C-004", "프로젝트에 해당 사용자의 좋아요가 존재하지 않습니다.");
+    PROJECT_LIKE_NOT_FOUND(NOT_FOUND, "PJ-C-004", "프로젝트에 해당 사용자의 좋아요가 존재하지 않습니다."),
+    PROJECT_DUPLICATE_SUBSCRIBE(BAD_REQUEST, "PJ-C-005", "이미 해당 프로젝트에 구독중입니다."),
+    PROJECT_SUBSCRIBE_NOT_FOUND(NOT_FOUND, "PJ-C-006", "해당 프로젝트에 구독중이지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectExceptionHandler.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectExceptionHandler.java
@@ -1,0 +1,44 @@
+package site.devtown.spadeworker.domain.project.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import site.devtown.spadeworker.global.exception.ExceptionResponse;
+
+import static site.devtown.spadeworker.domain.project.exception.ProjectExceptionCode.PROJECT_DUPLICATE_LIKE;
+import static site.devtown.spadeworker.domain.project.exception.ProjectExceptionCode.PROJECT_NOT_FOUND;
+
+@Slf4j
+@RestControllerAdvice
+public class ProjectExceptionHandler {
+
+    /**
+     * ProjectDuplicateLikeException 핸들링
+     */
+    @ExceptionHandler(ProjectDuplicateLikeException.class)
+    public ResponseEntity<ExceptionResponse> handleProjectDuplicateLikeException(
+            ProjectDuplicateLikeException e
+    ) {
+        log.error("{}", e.getMessage());
+        return new ResponseEntity<>(
+                ExceptionResponse.of(PROJECT_DUPLICATE_LIKE, PROJECT_DUPLICATE_LIKE.getMessage()),
+                HttpStatus.valueOf(PROJECT_DUPLICATE_LIKE.getHttpStatus().value())
+        );
+    }
+
+    /**
+     * ProjectLikeNotFoundException 핸들링
+     */
+    @ExceptionHandler(ProjectLikeNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleProjectLikeNotFoundException(
+            ProjectLikeNotFoundException e
+    ) {
+        log.error("{}", e.getMessage());
+        return new ResponseEntity<>(
+                ExceptionResponse.of(PROJECT_NOT_FOUND, PROJECT_NOT_FOUND.getMessage()),
+                HttpStatus.valueOf(PROJECT_NOT_FOUND.getHttpStatus().value())
+        );
+    }
+}

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectExceptionHandler.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectExceptionHandler.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import site.devtown.spadeworker.global.exception.ExceptionResponse;
 
-import static site.devtown.spadeworker.domain.project.exception.ProjectExceptionCode.PROJECT_DUPLICATE_LIKE;
-import static site.devtown.spadeworker.domain.project.exception.ProjectExceptionCode.PROJECT_NOT_FOUND;
+import static site.devtown.spadeworker.domain.project.exception.ProjectExceptionCode.*;
+import static site.devtown.spadeworker.domain.project.exception.ProjectExceptionCode.PROJECT_DUPLICATE_SUBSCRIBE;
 
 @Slf4j
 @RestControllerAdvice
@@ -29,7 +29,7 @@ public class ProjectExceptionHandler {
     }
 
     /**
-     * ProjectLikeNotFoundException 핸들링
+     * ProjectDuplicateSubscribeException 핸들링
      */
     @ExceptionHandler(ProjectLikeNotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleProjectLikeNotFoundException(
@@ -39,6 +39,34 @@ public class ProjectExceptionHandler {
         return new ResponseEntity<>(
                 ExceptionResponse.of(PROJECT_NOT_FOUND, PROJECT_NOT_FOUND.getMessage()),
                 HttpStatus.valueOf(PROJECT_NOT_FOUND.getHttpStatus().value())
+        );
+    }
+
+    /**
+     * ProjectDuplicateSubscribeException 핸들링
+     */
+    @ExceptionHandler(ProjectDuplicateSubscribeException.class)
+    public ResponseEntity<ExceptionResponse> handleProjectDuplicateSubscribeException(
+            ProjectDuplicateSubscribeException e
+    ) {
+        log.error("{}", e.getMessage());
+        return new ResponseEntity<>(
+                ExceptionResponse.of(PROJECT_DUPLICATE_SUBSCRIBE, PROJECT_DUPLICATE_SUBSCRIBE.getMessage()),
+                HttpStatus.valueOf(PROJECT_DUPLICATE_SUBSCRIBE.getHttpStatus().value())
+        );
+    }
+
+    /**
+     * ProjectSubscribeNotFoundException 핸들링
+     */
+    @ExceptionHandler(ProjectSubscribeNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleProjectSubscribeNotFoundException(
+            ProjectSubscribeNotFoundException e
+    ) {
+        log.error("{}", e.getMessage());
+        return new ResponseEntity<>(
+                ExceptionResponse.of(PROJECT_SUBSCRIBE_NOT_FOUND, PROJECT_SUBSCRIBE_NOT_FOUND.getMessage()),
+                HttpStatus.valueOf(PROJECT_SUBSCRIBE_NOT_FOUND.getHttpStatus().value())
         );
     }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectLikeNotFoundException.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectLikeNotFoundException.java
@@ -1,0 +1,7 @@
+package site.devtown.spadeworker.domain.project.exception;
+
+public class ProjectLikeNotFoundException extends RuntimeException {
+    public ProjectLikeNotFoundException() {
+        super("프로젝트에 해당 사용자의 좋아요가 존재하지 않습니다.");
+    }
+}

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectLikeNotFoundException.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectLikeNotFoundException.java
@@ -1,7 +1,9 @@
 package site.devtown.spadeworker.domain.project.exception;
 
+import static site.devtown.spadeworker.domain.project.exception.ProjectExceptionCode.*;
+
 public class ProjectLikeNotFoundException extends RuntimeException {
     public ProjectLikeNotFoundException() {
-        super("프로젝트에 해당 사용자의 좋아요가 존재하지 않습니다.");
+        super(PROJECT_LIKE_NOT_FOUND.getMessage());
     }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectSubscribeNotFoundException.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/exception/ProjectSubscribeNotFoundException.java
@@ -1,0 +1,9 @@
+package site.devtown.spadeworker.domain.project.exception;
+
+import static site.devtown.spadeworker.domain.project.exception.ProjectExceptionCode.*;
+
+public class ProjectSubscribeNotFoundException extends RuntimeException {
+    public ProjectSubscribeNotFoundException() {
+        super(PROJECT_SUBSCRIBE_NOT_FOUND.getMessage());
+    }
+}

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/repository/ProjectLikeRepository.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/repository/ProjectLikeRepository.java
@@ -1,8 +1,16 @@
 package site.devtown.spadeworker.domain.project.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import site.devtown.spadeworker.domain.project.entity.Project;
 import site.devtown.spadeworker.domain.project.entity.ProjectLike;
+import site.devtown.spadeworker.domain.user.model.entity.User;
+
+import java.util.Optional;
 
 public interface ProjectLikeRepository
         extends JpaRepository<ProjectLike, Long> {
+
+    Boolean existsByProjectAndUser(Project project, User user);
+
+    Optional<ProjectLike> findByProjectAndUser(Project project, User user);
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/repository/ProjectLikeRepository.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/repository/ProjectLikeRepository.java
@@ -13,4 +13,6 @@ public interface ProjectLikeRepository
     Boolean existsByProjectAndUser(Project project, User user);
 
     Optional<ProjectLike> findByProjectAndUser(Project project, User user);
+
+    int countAllByProject(Project project);
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/repository/ProjectSubscribeRepository.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/repository/ProjectSubscribeRepository.java
@@ -1,8 +1,16 @@
 package site.devtown.spadeworker.domain.project.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import site.devtown.spadeworker.domain.project.entity.Project;
 import site.devtown.spadeworker.domain.project.entity.ProjectSubscribe;
+import site.devtown.spadeworker.domain.user.model.entity.User;
+
+import java.util.Optional;
 
 public interface ProjectSubscribeRepository
         extends JpaRepository<ProjectSubscribe, Long> {
+
+    Boolean existsByProjectAndSubscriber(Project project, User subscriber);
+
+    Optional<ProjectSubscribe> findByProjectAndSubscriber(Project project, User subscriber);
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/repository/ProjectSubscribeRepository.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/repository/ProjectSubscribeRepository.java
@@ -13,4 +13,6 @@ public interface ProjectSubscribeRepository
     Boolean existsByProjectAndSubscriber(Project project, User subscriber);
 
     Optional<ProjectSubscribe> findByProjectAndSubscriber(Project project, User subscriber);
+
+    int countAllByProject(Project project);
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/service/ProjectService.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/service/ProjectService.java
@@ -60,7 +60,11 @@ public class ProjectService {
     public List<ProjectDto> getAllProjects() {
         return projectRepository.findAll()
                 .stream()
-                .map(ProjectDto::from)
+                .map(p -> ProjectDto.from(
+                        p,
+                        projectLikeRepository.countAllByProject(p),
+                        projectSubscribeRepository.countAllByProject(p))
+                )
                 .toList();
     }
 
@@ -72,7 +76,11 @@ public class ProjectService {
             Long projectId
     ) {
         return projectRepository.findById(projectId)
-                .map(ProjectDto::from)
+                .map(p -> ProjectDto.from(
+                        p,
+                        projectLikeRepository.countAllByProject(p),
+                        projectSubscribeRepository.countAllByProject(p))
+                )
                 .orElseThrow(
                         () -> new ResourceNotFoundException(PROJECT_NOT_FOUND)
                 );

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/service/ProjectService.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/service/ProjectService.java
@@ -204,12 +204,4 @@ public class ProjectService {
         // 이미지가 변경되지 않았을 경우
         return savedImageUri;
     }
-
-    // 특정 프로젝트 및 사용자의 좋아요가 있는지 조회
-    private boolean isProjectLikeExist(Project project, User user) {
-        return projectLikeRepository.existsByProjectAndUser(
-                project,
-                user
-        );
-    }
 }


### PR DESCRIPTION
프로젝트 도메인에 좋아요 및 구독 시스템을 개발하였다.

- 좋아요 시스템
  - 사용자 프로젝트간 좋아요 등록 및 취소
  - 관련 예외 처리
- 구독 시스템
  - 사용자 프로젝트간 구독 등록 및 취소
  - 관련 예외 처리
- 프로젝트를 단건 & 전체 조회할 때 해당 프로젝트의 좋아요 수 및 구독자 수가 함께 조회되도록 리펙토링

This closes #45 