### PR TITLE
Project & Auth 도메인 응답 데이터 구조 변경 및 security config 설정 변경

### DIFF
--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/controller/AuthController.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/controller/AuthController.java
@@ -3,9 +3,7 @@ package site.devtown.spadeworker.domain.auth.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import site.devtown.spadeworker.domain.auth.dto.ReissueTokenResponse;
 import site.devtown.spadeworker.domain.auth.exception.InvalidTokenException;
 import site.devtown.spadeworker.domain.auth.service.JwtService;
@@ -44,7 +42,7 @@ public class AuthController {
     /**
      * 인증 토큰 재발급 API
      */
-    @GetMapping("/refresh")
+    @PostMapping("/refresh")
     public SingleResult<ReissueTokenResponse> reissueToken(
             HttpServletRequest request,
             HttpServletResponse response
@@ -83,7 +81,7 @@ public class AuthController {
     /**
      * 로그아웃 API
      */
-    @GetMapping("/logout")
+    @DeleteMapping("/logout")
     public CommonResult logout(
             HttpServletRequest request
     ) {

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/controller/AuthController.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.PropertySource;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import site.devtown.spadeworker.domain.auth.dto.ReissueTokenResponse;
 import site.devtown.spadeworker.domain.auth.exception.InvalidTokenException;
 import site.devtown.spadeworker.domain.auth.service.JwtService;
 import site.devtown.spadeworker.global.factory.YamlPropertySourceFactory;
@@ -40,8 +41,11 @@ public class AuthController {
 
     private final static String REFRESH_TOKEN = "refresh_token";
 
+    /**
+     * 인증 토큰 재발급 API
+     */
     @GetMapping("/refresh")
-    public SingleResult<String> reissueToken(
+    public SingleResult<ReissueTokenResponse> reissueToken(
             HttpServletRequest request,
             HttpServletResponse response
     ) {
@@ -71,11 +75,14 @@ public class AuthController {
 
         return responseService.getSingleResult(
                 OK.value(),
-                "재발급되었습니다.",
-                newTokens.get("accessToken")
+                "성공적으로 토큰이 재발급되었습니다.",
+                ReissueTokenResponse.of(newTokens.get("accessToken"))
         );
     }
 
+    /**
+     * 로그아웃 API
+     */
     @GetMapping("/logout")
     public CommonResult logout(
             HttpServletRequest request

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/dto/ReissueTokenResponse.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/dto/ReissueTokenResponse.java
@@ -1,0 +1,9 @@
+package site.devtown.spadeworker.domain.auth.dto;
+
+public record ReissueTokenResponse(
+        String newAccessToken
+) {
+    public static ReissueTokenResponse of(String newAccessToken) {
+        return new ReissueTokenResponse(newAccessToken);
+    }
+}

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/service/JwtService.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/service/JwtService.java
@@ -14,8 +14,10 @@ import site.devtown.spadeworker.domain.auth.repository.UserRefreshTokenRepositor
 import site.devtown.spadeworker.domain.auth.token.AuthToken;
 import site.devtown.spadeworker.domain.auth.token.AuthTokenProvider;
 import site.devtown.spadeworker.domain.auth.token.UserRefreshToken;
+import site.devtown.spadeworker.domain.user.exception.UserExceptionCode;
 import site.devtown.spadeworker.domain.user.model.entity.User;
 import site.devtown.spadeworker.domain.user.repository.UserRepository;
+import site.devtown.spadeworker.global.exception.ResourceNotFoundException;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.Arrays;
@@ -24,6 +26,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static site.devtown.spadeworker.domain.auth.exception.AuthExceptionCode.INVALID_REFRESH_TOKEN;
+import static site.devtown.spadeworker.domain.user.exception.UserExceptionCode.*;
 
 @RequiredArgsConstructor
 @Service
@@ -114,15 +117,17 @@ public class JwtService {
     /**
      * JWT 값을 기반으로 사용자 인가 조회
      */
+    @Transactional(readOnly = true)
     public Authentication getAuthentication(AuthToken accessToken) {
         // access token 검증
         accessToken.validate();
 
         // access token claims 조회
         Claims claims = accessToken.getTokenClaims();
+
         // claims 값을 기반으로 사용자 Entity 조회
         User user = userRepository.findByPersonalId(claims.getSubject())
-                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 사용자입니다."));
+                .orElseThrow(() -> new ResourceNotFoundException(USER_NOT_FOUND));
 
         // claims 값을 기반으로 사용자의 권한 조회
         Collection<? extends GrantedAuthority> roles = getUserAuthority(claims.get("roles", String.class));

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/service/JwtService.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/service/JwtService.java
@@ -14,19 +14,17 @@ import site.devtown.spadeworker.domain.auth.repository.UserRefreshTokenRepositor
 import site.devtown.spadeworker.domain.auth.token.AuthToken;
 import site.devtown.spadeworker.domain.auth.token.AuthTokenProvider;
 import site.devtown.spadeworker.domain.auth.token.UserRefreshToken;
-import site.devtown.spadeworker.domain.user.exception.UserExceptionCode;
 import site.devtown.spadeworker.domain.user.model.entity.User;
 import site.devtown.spadeworker.domain.user.repository.UserRepository;
 import site.devtown.spadeworker.global.exception.ResourceNotFoundException;
 
-import javax.persistence.EntityNotFoundException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import static site.devtown.spadeworker.domain.auth.exception.AuthExceptionCode.INVALID_REFRESH_TOKEN;
-import static site.devtown.spadeworker.domain.user.exception.UserExceptionCode.*;
+import static site.devtown.spadeworker.domain.user.exception.UserExceptionCode.USER_NOT_FOUND;
 
 @RequiredArgsConstructor
 @Service

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/controller/ProjectController.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/controller/ProjectController.java
@@ -53,13 +53,16 @@ public class ProjectController {
      * 프로젝트 생성 API
      */
     @PostMapping()
-    public SingleResult<Long> createProject(
+    public CommonResult createProject(
             @ModelAttribute @Valid CreateProjectRequest request
     ) throws Exception {
-        return responseService.getSingleResult(
+
+        // 프로젝트 생성 비즈니스 로직 수행
+        projectService.createProject(request);
+
+        return responseService.getSuccessResult(
                 OK.value(),
-                "성공적으로 프로젝트가 생성되었습니다.",
-                projectService.createProject(request)
+                "성공적으로 프로젝트가 생성되었습니다."
         );
     }
 
@@ -67,17 +70,17 @@ public class ProjectController {
      * 프로젝트 수정 API
      */
     @PatchMapping("/{projectId}")
-    public SingleResult<Long> updateProject(
+    public CommonResult updateProject(
             @PathVariable Long projectId,
             @ModelAttribute @Valid UpdateProjectRequest request
     ) throws Exception {
-        return responseService.getSingleResult(
+
+        // 프로젝트 수정 비즈니스 로직 수행
+        projectService.updateProject(projectId, request);
+
+        return responseService.getSuccessResult(
                 OK.value(),
-                "성공적으로 프로젝트가 수정되었습니다.",
-                projectService.updateProject(
-                        projectId,
-                        request
-                )
+                "성공적으로 프로젝트가 수정되었습니다."
         );
     }
 

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/service/ProjectService.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/service/ProjectService.java
@@ -89,7 +89,7 @@ public class ProjectService {
     /**
      * 프로젝트 생성 비즈니스 로직
      */
-    public Long createProject(
+    public void createProject(
             CreateProjectRequest request
     ) throws Exception {
 
@@ -101,13 +101,13 @@ public class ProjectService {
         );
 
         // create 로직 진행
-        return projectRepository.save(project).getId();
+        projectRepository.save(project);
     }
 
     /**
      * 프로젝트 수정 비즈니스 로직
      */
-    public Long updateProject(
+    public void updateProject(
             Long projectId,
             UpdateProjectRequest request
     ) throws Exception {
@@ -129,8 +129,6 @@ public class ProjectService {
                         savedProject.getThumbnailImageUri()
                 )
         );
-
-        return savedProject.getId();
     }
 
     /**

--- a/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/SecurityConfig.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/SecurityConfig.java
@@ -51,7 +51,10 @@ public class SecurityConfig {
         http
                 .authorizeRequests()
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+                // AUTH API
                 .antMatchers(GET, "/api/auth/refresh").permitAll()
+                // Project API
+                .antMatchers(GET, "/api/projects/**").permitAll()
                 // 나머지는 모두 인증 필요
                 .anyRequest().authenticated();
 


### PR DESCRIPTION
Project 도메인과 Auth 도메인에 다음과 같은 변경사항이 적용되었다.

- Project
  - 조회 API를 인증되지 않은 사용자도 호출할 수 있도록 인증 예외 설정
  - Response 데이터 구조 수정
- Auth
  - API Http Method 수정
  - JwtService 로직 리펙토링
  - Response 데이터 구조 수정

This closes #55 