### PR TITLE
[Fix] 토큰 필터에서 예외를 제대로 잡지 못하는 문제 원인 파악 및 조치

### DIFF
--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/exception/CustomAuthenticationEntryPoint.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/exception/CustomAuthenticationEntryPoint.java
@@ -1,5 +1,6 @@
 package site.devtown.spadeworker.domain.auth.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import site.devtown.spadeworker.global.exception.ExceptionResponse;
@@ -9,6 +10,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static site.devtown.spadeworker.domain.auth.exception.AuthExceptionCode.AUTHENTICATION_ERROR;
+
+@Slf4j
 public class CustomAuthenticationEntryPoint
         implements AuthenticationEntryPoint {
 
@@ -20,16 +24,26 @@ public class CustomAuthenticationEntryPoint
             HttpServletResponse response,
             AuthenticationException authException
     ) throws IOException, ServletException {
-        setResponse(response, (AuthExceptionCode) request.getAttribute(exceptionAttributeName));
+
+        AuthExceptionCode exceptionCode = (AuthExceptionCode) request.getAttribute(exceptionAttributeName);
+
+        // 사용자 정의 예외의 Enum Code 가 넘어온 경우
+        if (exceptionCode != null) {
+            setResponse(response, exceptionCode);
+        } else {    // Error Message 만 넘어온 경우 범용 인증 예외 코드를 던짐
+            log.error("Responding with unauthorized error. Message := {}", authException.getMessage());
+            setResponse(response, AUTHENTICATION_ERROR);
+        }
     }
 
-    // 한글 출력을 위해 getWriter() 사용
+    // 에러 응답 생성 메소드
     private void setResponse(
             HttpServletResponse response,
             AuthExceptionCode exceptionCode
     ) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        // 한글 출력을 위해 getWriter() 사용
         response.getWriter().print(ExceptionResponse.of(exceptionCode).convertJson());
     }
 }

--- a/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/SecurityConfig.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/global/config/security/SecurityConfig.java
@@ -20,6 +20,7 @@ import site.devtown.spadeworker.domain.auth.repository.OAuth2AuthorizationReques
 import site.devtown.spadeworker.domain.auth.service.JwtService;
 
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
 
 @RequiredArgsConstructor
 @Configuration
@@ -52,7 +53,7 @@ public class SecurityConfig {
                 .authorizeRequests()
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                 // AUTH API
-                .antMatchers(GET, "/api/auth/refresh").permitAll()
+                .antMatchers(POST, "/api/auth/refresh").permitAll()
                 // Project API
                 .antMatchers(GET, "/api/projects/**").permitAll()
                 // 나머지는 모두 인증 필요


### PR DESCRIPTION
문제 : 토큰 재발급 API의 잘못된 요청이 갔을때 일부 예외가 잡히지 않는 문제가 발생함

조치 내용 : 사용자 정의 예외 외 예외가 발생 시 해당 예외 들은 Enum으로 직접 정의한 예외 코드가 들어가지 않기 때문에 NullPointerException이 발생한다. 따라서 직접 정의한 예외 외 예외가 발생할 경우 범용 인증 예외 코드를 사용해서 예외 응답을 생성하도록 조치하였다.

This closes #57 