### PR TITLE
로그아웃 API 호출 시 해당 사용자가 로그인 중이 아닐 경우 예외를 발생하도록 리펙토링

### DIFF
--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/exception/AuthExceptionCode.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/exception/AuthExceptionCode.java
@@ -30,6 +30,7 @@ public enum AuthExceptionCode
      */
     OAUTH_PROVIDER_MISMATCH(BAD_REQUEST, "AT-C-100", "일치하지 않는 인증 제공자 입니다."),
     INVALID_USER_ROLE(FORBIDDEN, "AT-C-101", "유효하지 않은 사용자 권한입니다."),
+    LOGGED_USER_NOT_FOUND(NOT_FOUND, "AT-C-102", "현재 로그인 중이지 않습니다."),
 
     /**
      * Common Exception

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/exception/AuthExceptionHandler.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/exception/AuthExceptionHandler.java
@@ -62,6 +62,21 @@ public class AuthExceptionHandler {
     }
 
     /**
+     * LoggedUserNotFoundException 핸들링
+     * Custom Exception
+     */
+    @ExceptionHandler(LoggedUserNotFoundException.class)
+    protected ResponseEntity<ExceptionResponse> handleLoggedUserNotFoundException(
+            LoggedUserNotFoundException e
+    ) {
+        log.error("handle LoggedUserNotFoundException");
+        return new ResponseEntity<>(
+                ExceptionResponse.of(LOGGED_USER_NOT_FOUND, e.getMessage()),
+                HttpStatus.valueOf(LOGGED_USER_NOT_FOUND.getHttpStatus().value())
+        );
+    }
+
+    /**
      * AuthenticationException 핸들링
      * Built-in Exception
      */

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/exception/LoggedUserNotFoundException.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/exception/LoggedUserNotFoundException.java
@@ -1,0 +1,9 @@
+package site.devtown.spadeworker.domain.auth.exception;
+
+import static site.devtown.spadeworker.domain.auth.exception.AuthExceptionCode.LOGGED_USER_NOT_FOUND;
+
+public class LoggedUserNotFoundException extends RuntimeException {
+    public LoggedUserNotFoundException() {
+        super(LOGGED_USER_NOT_FOUND.getMessage());
+    }
+}

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/repository/UserRefreshTokenRepository.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/auth/repository/UserRefreshTokenRepository.java
@@ -13,4 +13,6 @@ public interface UserRefreshTokenRepository
     Optional<UserRefreshToken> findByPersonalIdAndTokenValue(String personalId, String token);
 
     void deleteAllByPersonalId(String personalId);
+
+    boolean existsByPersonalId(String personalId);
 }


### PR DESCRIPTION
로그아웃 API가 호출될 경우, 만약 해당 사용자가 로그인 중이 아니라면 예외를 발생하도록 리펙토링하였다.

- AuthExceptionCode에 관련 예외 코드 추가
- 로그인 중인 사용자가 없을경우 발생하는 사용자 정의 예외 추가 및 핸들러에 등록
- 토큰에서 조회한 사용자의 personalId를 기반으로 해당 사용자의 refresh token이 존재하는지 조회하는 쿼리 메서드 생성
- JwtService에 관련 로직 추가

This closes #59 