### PR TITLE
[Fix] 프로젝트 생성/수정시 썸네일이 Null일 경우 예외를 제대로 잡지 못하는 문제 조치

### DIFF
--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/dto/CreateProjectRequest.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/dto/CreateProjectRequest.java
@@ -6,7 +6,6 @@ import site.devtown.spadeworker.domain.project.validation.ProjectThumbnailImageV
 import site.devtown.spadeworker.domain.project.validation.ProjectTitleDuplicateValidate;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 public record CreateProjectRequest(
         @NotBlank(message = "프로젝트 제목은 필수 값입니다.")
@@ -18,7 +17,7 @@ public record CreateProjectRequest(
         @Length(min = 1, max = 500, message = "프로젝트 설명 길이 제한은 1이상 500이하 입니다.")
         String description,
 
-        @NotNull(message = "프로젝트 프로필이미지 파일은 필수 값입니다.")
         @ProjectThumbnailImageValidate
         MultipartFile thumbnailImage
-) {}
+) {
+}

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/dto/UpdateProjectRequest.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/dto/UpdateProjectRequest.java
@@ -6,7 +6,6 @@ import site.devtown.spadeworker.domain.project.validation.ProjectThumbnailImageV
 import site.devtown.spadeworker.domain.project.validation.ProjectTitleDuplicateValidate;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 public record UpdateProjectRequest(
         @NotBlank(message = "프로젝트 제목은 필수 값입니다.")
@@ -18,7 +17,7 @@ public record UpdateProjectRequest(
         @Length(min = 1, max = 500, message = "프로젝트 설명 길이 제한은 1이상 500이하 입니다.")
         String description,
 
-        @NotNull(message = "프로젝트 프로필이미지 파일은 필수 값입니다.")
         @ProjectThumbnailImageValidate
         MultipartFile thumbnailImage
-) {}
+) {
+}

--- a/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/validation/ProjectThumbnailImageValidator.java
+++ b/spadeworker/src/main/java/site/devtown/spadeworker/domain/project/validation/ProjectThumbnailImageValidator.java
@@ -30,6 +30,14 @@ public class ProjectThumbnailImageValidator
             MultipartFile uploadImage,
             ConstraintValidatorContext context
     ) {
+        // 프로필 썸네일이 Null 인지 체크
+        if (uploadImage == null) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("프로필 썸네일은 필수 값 입니다.")
+                    .addConstraintViolation();
+            return false;
+        }
+
         // 이미지 확장자 검증
         if (!validateImageExtension(ImageUtil.getImageExtension(uploadImage.getOriginalFilename()))) {
             context.disableDefaultConstraintViolation();


### PR DESCRIPTION
원인 : 직접 생성한 커스텀 어노테이션이 먼저 실행되면서 예상했던 예외와는 다른 예외가 발생하였다.
해결 : 기존 @NotNull 어노테이션을 제거하고 커스텀한 에노테이션에 null값을 검증하는 로직을 추가해주었다.

This closes #62 